### PR TITLE
feat(HW#2): kubernetes-controllers

### DIFF
--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+  namespace: homework
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+       app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      initContainers:
+      - name: nginx-init
+        image: busybox:1.28
+        command: ['sh', '-c', 'wget -O /init/index.html http://example.com/index.html']
+        volumeMounts:
+        - mountPath: /init
+          name: nginx-volume
+      containers:
+      - name: nginx
+        image: 310581/otus-kuber-2024-01-nginx:latest
+        workingDir: /homework
+        ports:
+        - containerPort: 8000
+        volumeMounts:
+        - mountPath: /homework
+          name: nginx-volume
+        lifecycle:
+          preStop:
+            exec:
+              command: ['sh', '-c', 'rm -rf /homework/index.html']
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /homework/index.html
+      volumes:
+      - name: nginx-volume
+        emptyDir:
+          sizeLimit: 50Mi
+      nodeSelector:
+        homework: 'true'

--- a/kubernetes-controllers/namespace.yaml
+++ b/kubernetes-controllers/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework


### PR DESCRIPTION
ns + deployment + readiness probe + nodeSelector

# Выполнено ДЗ №2

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- создать манифест namespace.yaml
- создать манифест deployment.yaml
  - Будет создаваться в namespace homework
  - Запускает 3 экземпляра пода, полностью аналогичных по спецификации прошлому ДЗ
  - Будет иметь readiness пробу, проверяющую наличие файла /homework/index.html
  - Будет иметь стратегию обновления RollingUpdate, настроенную так, что в процессе обновления может быть недоступен максимум 1 под
  - Задание со звёздочкой: Добавить к манифесту deployment-а спецификацию, обеспечивающую запуск подов деплоймента, только на нодах кластера, имеющих метку homework=true

## Как запустить проект:
 - kubectl apply -f namespace.yaml,deployment.yaml

## Как проверить работоспособность:
 - Выполнить на ноде кластера команду: curl http://<pod_ip>:8000, где pod_ip - IP-адрес пода nginx. В результате получим html-страничку с текстом "Example Domain"

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
