### PR TITLE
feat(HW#3): kubernetes-networks

### DIFF
--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dp-web
+  namespace: homework
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+       app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      initContainers:
+      - name: nginx-init
+        image: busybox:1.28
+        command: ['sh', '-c', 'wget -O /init/index.html http://example.com/index.html']
+        volumeMounts:
+        - mountPath: /init
+          name: nginx-volume
+      containers:
+      - name: nginx
+        image: 310581/otus-kuber-2024-01-nginx:latest
+        workingDir: /homework
+        ports:
+        - containerPort: 8000
+        volumeMounts:
+        - mountPath: /homework
+          name: nginx-volume
+        lifecycle:
+          preStop:
+            exec:
+              command: ['sh', '-c', 'rm -rf /homework/index.html']
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+          failureThreshold: 1
+          periodSeconds: 5
+      volumes:
+      - name: nginx-volume
+        emptyDir:
+          sizeLimit: 50Mi
+      nodeSelector:
+        homework: 'true'

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-nginx
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /homepage
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - path: /index.html
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: svc-nginx-cip
+            port:
+              number: 80

--- a/kubernetes-networks/ingress_upd.yaml
+++ b/kubernetes-networks/ingress_upd.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: ing-nginx
   namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /homepage
 spec:
   ingressClassName: nginx
   rules:

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-nginx-cip
+  namespace: homework
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: ClusterIP


### PR DESCRIPTION
readiness probe(httpGet) + service(ClusterIP) + ingress + rewrite

# Выполнено ДЗ №3

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
  - Изменить readiness-пробу в манифесте deployment.yaml из проúлого ДЗ на httpGet, вызывающую URL /index.html
  - создать манифест service.yaml, описывающий сервис типа ClusterIP
  - Создать манифест ingress.yaml, в котором будет описан объект типа ingress, направляющий все http запросы к хосту homework.otus на ранее созданный сервис. В результате запрос http://homework.otus/index.html должен отдавать код html страницы, находящийся в подах
  - Задание со звёздочкой: Доработать манифест ingress.yaml, описав в нем rewrite-правила так, чтобы обращение по адресу http://homework.otus/index.html форвардилось на http://homework.otus/homepage (файл ingress_upd.yaml)

## Как запустить проект:
 - kubectl apply -f namespace.yaml,deployment.yaml,service.yaml,ingress.yaml

## Как проверить работоспособность:
- Выполнить на ноде кластера команду: curl http://<pod_ip>:8000, где pod_ip - IP-адрес пода nginx. В результате получим html-страничку с текстом "Example Domain"

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
