### PR TITLE
feat(HW#4): kubernetes-volumes

### DIFF
--- a/kubernetes-volumes/cm.yaml
+++ b/kubernetes-volumes/cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuber-cm
+data:
+  dbuser: "rootENV"
+  dbpass: "qwertyENV"
+  dbconfig: |
+    dbuser: root
+    dbpass: qwerty

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dp-web
+  namespace: homework
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+       app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      initContainers:
+      - name: nginx-init
+        image: busybox:1.28
+        command: ['sh', '-c', 'wget -O /init/index.html http://example.com/index.html']
+        volumeMounts:
+        - mountPath: /init
+          name: nginx-volume
+      containers:
+      - name: nginx
+        image: 310581/otus-kuber-2024-01-nginx:latest
+        workingDir: /homework
+        ports:
+        - containerPort: 8000
+        volumeMounts:
+        - name: nginx-volume
+          mountPath: /homework
+        - name: cm-conf
+          mountPath: /homework/conf
+          readOnly: true
+        lifecycle:
+          preStop:
+            exec:
+              command: ['sh', '-c', 'rm -rf /homework/index.html']
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+          failureThreshold: 1
+          periodSeconds: 5
+      volumes:
+      - name: nginx-volume
+        persistentVolumeClaim:
+          claimName: kuber-pvc
+      - name: cm-conf
+        configMap:
+          name: kuber-cm
+          items:
+            - key: "dbconfig"
+              path: "dbconfig"
+      nodeSelector:
+        homework: 'true'

--- a/kubernetes-volumes/ingress.yaml
+++ b/kubernetes-volumes/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-nginx
+  namespace: homework
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - path: /index.html
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: svc-nginx-cip
+            port:
+              number: 80
+      - path: /conf/dbconfig
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: svc-nginx-cip
+            port:
+              number: 80

--- a/kubernetes-volumes/namespace.yaml
+++ b/kubernetes-volumes/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-volumes/pv.yaml
+++ b/kubernetes-volumes/pv.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kuber-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 100Mi
+  hostPath:
+    path: /data/pv001/

--- a/kubernetes-volumes/pvc.yaml
+++ b/kubernetes-volumes/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kuber-pvc
+  namespace: homework
+spec:
+  storageClassName: "kuber-sc" # Empty string must be explicitly set otherwise default StorageClass will be set
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Mi

--- a/kubernetes-volumes/service.yaml
+++ b/kubernetes-volumes/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-nginx-cip
+  namespace: homework
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: ClusterIP

--- a/kubernetes-volumes/storageClass.yaml
+++ b/kubernetes-volumes/storageClass.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: kuber-sc
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain # default value is Delete
+allowVolumeExpansion: true


### PR DESCRIPTION
# Выполнено ДЗ №4

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
  - Создать манифест pvc.yaml, описывающий PersistentVolumeClaim, запрашивающий хранилище с storageClass по-умолчанию;
  - Создать манифест cm.yaml для объекта типа conﬁgMap, описывающий произвольный набор пар ключ-значение;
  - В манифесте deployment.yaml изменить спецификацию volume типа emptyDir, который монтируется в init и основной контейнер, на pvc, созданный в предыдущем пункте;
  - В манифесте deployment.yaml добавить монтирование ранее созданного conﬁgMap как volume к основному контейнеру пода в директорию /homework/conf, так, чтобы его содержимое можно было получить, обратившись по url  /conf/dbconfig

## Как запустить проект (minikube):
 - minikube start
 - kubectl label nodes minikube homework=true
 - git clone https://github.com/Kuber-2024-02OTUS/latsygin_repo.git
 - cd latsygin_repo/kubernetes-volumes
 - kubectl apply -f .

## Как проверить работоспособность:
- Выполнить на ноде кластера команду: 
_curl http://<pod_ip>:8000/conf/dbconfig_

где pod_ip - IP-адрес пода nginx. В результате получим содержание **cm.yaml** а именно dbuser и dbpass.

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
