### PR TITLE
feat(HW#8): kubernetes-monitoring

### DIFF
--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dp-web
+  namespace: homework
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+       app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      initContainers:
+      - name: nginx-init
+        image: busybox:1.28
+        command: ['sh', '-c', 'wget -O /init/index.html http://example.com/index.html']
+        volumeMounts:
+        - mountPath: /init
+          name: nginx-volume
+      containers:
+      - name: nginx
+        image: 310581/otus-kuber-2024-01-nginx:1.0.1
+        workingDir: /homework
+        ports:
+        - containerPort: 8000
+        volumeMounts:
+        - mountPath: /homework
+          name: nginx-volume
+        lifecycle:
+          preStop:
+            exec:
+              command: ['sh', '-c', 'rm -rf /homework/index.html']
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+          failureThreshold: 1
+          periodSeconds: 5
+      - name: nginx-exporter
+        image: 'nginx/nginx-prometheus-exporter:1.1.0'
+        args:
+          - '-nginx.scrape-uri=http://localhost:8000/basic_status'
+        resources:
+          limits:
+            memory: 128Mi
+            cpu: 500m
+        ports:
+          - containerPort: 9113
+      volumes:
+      - name: nginx-volume
+        emptyDir:
+          sizeLimit: 50Mi

--- a/kubernetes-monitoring/ingress.yaml
+++ b/kubernetes-monitoring/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-nginx
+  namespace: homework
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - path: /index.html
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: svc-nginx-cip
+            port:
+              number: 80
+      - path: /basic_status
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: svc-nginx-cip
+            port:
+              number: 80
+      - path: /metrics
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: svc-nginx-exp
+            port:
+              number: 9113

--- a/kubernetes-monitoring/namespaces.yaml
+++ b/kubernetes-monitoring/namespaces.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring

--- a/kubernetes-monitoring/pvc.yaml
+++ b/kubernetes-monitoring/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kuber-pvc
+  namespace: homework
+spec:
+  storageClassName: "kuber-sc" # Empty string must be explicitly set otherwise default StorageClass will be set
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Mi

--- a/kubernetes-monitoring/service.yaml
+++ b/kubernetes-monitoring/service.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-nginx-exp
+  namespace: homework
+  labels:
+    app: nginx
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9113
+      name: svc-nginx-exporter
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-nginx-cip
+  namespace: homework
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+      name: svc-nginx-cip
+  type: ClusterIP

--- a/kubernetes-monitoring/servicemonitor.yaml
+++ b/kubernetes-monitoring/servicemonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-sm
+  namespace: homework
+spec:
+  endpoints:
+  - path: /metrics
+    port: svc-nginx-exporter
+  selector:
+    matchLabels:
+      app: nginx

--- a/kubernetes-monitoring/values.yaml
+++ b/kubernetes-monitoring/values.yaml
@@ -1,0 +1,4 @@
+prometheus:
+  prometheusSpec:
+    podMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
servicemonitor + kube-prometheus-stack

# Выполнено ДЗ №8

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Необходимо создать кастомный образ nginx, отдающий свои метрики на определенном endpoint ( пример из офф документации в разделе ссылок);
 - Установить в кластер Prometheus-operator любым удобным вам способом (рекомендуется ставить или по ссылке из офф документации, либо через helm-чарт);
 - Создать deployment запускающий ваш кастомный nginx образ и service для него;
 - Настроить запуск nginx prometheus exporter (отдельным подом или в составе пода с nginx – не принципиально) и сконфигурировать его для сбора метрик с nginx;
 - Создать манифест serviceMonitor, описывающий сбор метрик с подов, которые вы создали.

## Как запустить проект:
 - kubectl apply -f .

## Как проверить работоспособность:
 перейти по ссылке  
 - http://homework.otus/index.html
 - http://homework.otus/metrics.html
 - http://homework.otus/basic_status

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
